### PR TITLE
Language Server: Correctly set the version in diagnostics

### DIFF
--- a/language-server/lambdananas-language-server.cabal
+++ b/language-server/lambdananas-language-server.cabal
@@ -56,6 +56,7 @@ library
     , mtl
     , process
     , text
+    , time
   default-language: Haskell2010
 
 executable lambdananas-language-server

--- a/language-server/package.yaml
+++ b/language-server/package.yaml
@@ -37,7 +37,7 @@ library:
     - lens
     - directory
     - filepath
-
+    - time
 executables:
   lambdananas-language-server:
     main:                Main.hs


### PR DESCRIPTION
Set the version of diagnostics to the current timestamp.
Not providing a version might confuse IDEs (e.g. VSCode), and not clear diagnostics